### PR TITLE
Include more metadata in feed

### DIFF
--- a/src/feed.njk
+++ b/src/feed.njk
@@ -7,7 +7,7 @@
     "title": "Stanford Literary Lab",
     "subtitle": "A research collective that applies computational criticism, in all its forms, to the study of literature.",
     "language": "en",
-    "url": "https://litlab.stanford.edu",
+    "url": "https://litlab.stanford.edu/",
     "author": {
       "name": "Stanford Literary Lab",
       "email": "malgeehe@stanford.edu"
@@ -18,9 +18,9 @@
 <?xml version="1.0" encoding="utf-8"?>
 <feed xmlns="http://www.w3.org/2005/Atom">
   <title>{{ site.title }}</title>
-  <subtitle>{{ site.subtitle }}</subtitle>
-  <link href="{{ site.feedUrl }}" rel="self"/>
-  <link href="{{ site.url }}"/>
+  <subtitle>{{ metadata.subtitle }}</subtitle>
+  <link href="{{ absoluteUrl(permalink) }}" rel="self"/>
+  <link href="{{ metadata.url }}"/>
   <updated>{{ collections.posts | getNewestCollectionItemDate | dateToRfc3339 }}</updated>
   <id>{{ metadata.url }}</id>
   <author>


### PR DESCRIPTION
Based on [feed validation feedback](https://validator.w3.org/feed/check.cgi?url=https%3A%2F%2Flitlab.stanford.edu%2Ffeed.xml) I tried to address:

- the empty subtitle (referencing `metadata.subtitle`; perhaps `site.description` would have the same effect?)
- the missing `/` in the `id` element – although this may trip up feed readers who could consider the different ID a different feed
- the empty `href` (flagged as "relative URL") that was supposed to be the `self` link – I hope `absoluteUrl(permalink)` expands to exactly the URL of the feed
- the empty `href` that was supposed to link to the homepage

I did not test these results locally; I haven't used Eleventy at all.